### PR TITLE
Compiled suggestions from Spring IO Workshop

### DIFF
--- a/workshop/Step3.md
+++ b/workshop/Step3.md
@@ -58,12 +58,6 @@ Now build your OCI image
 pack build devnexus-workshop-app
 ```
 
-We can use buildpacks to generate a Software Bill of Materials (SBOM) using the following command
-
-```
-pack sbom ml-java-workshopp-app
-```
-
 ## IMPORTANT: Push the container image to Artifact Registry
 
 ```

--- a/workshop/Step4.md
+++ b/workshop/Step4.md
@@ -37,9 +37,16 @@ Options:
   -v, --version               version for sbom
 
 ```
-To demonstrate this flow, let’s look at a simple use case where ‘docker sbom’ is used to produce its data as SPDX JSON, which is then consumed by another tool. We’ll use Grype, Anchore’s open source vulnerability scanner, (Follow this [link](https://github.com/anchore/grype) to install it) to produce a vulnerability report without needing to contact any remote scanning services:
+To demonstrate this flow, let’s look at a simple use case where ‘docker sbom’ is used to produce its data as SPDX JSON, which is then consumed by another tool. We’ll use Grype, Anchore’s open source vulnerability scanner, to produce a vulnerability report without needing to contact any remote scanning services:
+
+Install grype
 ```
-docker scout sbom --format spdx us-east1-docker.pkg.dev/$PROJECT_ID/ml-java-workshopp/ml-java-workshopp-app | grype
+curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b .
+```
+
+Run Scout and pass the result to grype
+```
+docker scout sbom --format spdx us-east1-docker.pkg.dev/$PROJECT_ID/ml-java-workshopp/ml-java-workshopp-app | ./grype
 ```
 
 What actions should we take based on the output ?

--- a/workshop/Step5.md
+++ b/workshop/Step5.md
@@ -24,7 +24,7 @@ gcloud container --project $PROJECT_ID clusters create ml-java-workshopp \
 Edit the file `k8s/basic/deployment.yaml`:
 
 - Change the value of the `HUGGING_FACE_API_KEY` environment variable
-- Change the value of `PROJECT_ID` to match your project ID
+- Change the value of `image` (from `nice-ocean-419714`) to match your project ID (run `gcloud config list` in the cloud shell to get your project ID)
 
 Run the command below to deploy the app
 

--- a/workshop/Step6.md
+++ b/workshop/Step6.md
@@ -22,7 +22,7 @@ Note that the value of the secret has been Base64 encoded
 
 Edit the file `k8s/secure/deployment.yaml`:
 
-- Change the value of `image` (from `nice-ocean-419714`) to match your project ID (run `gcloud config list` in the cloud shell to get your project ID)
+- Change the value of `PROJECT_ID` to match your project ID (run `gcloud config list` in the cloud shell to get your projectid value)
 
 Run the command below to deploy the app
 

--- a/workshop/Step6.md
+++ b/workshop/Step6.md
@@ -2,7 +2,7 @@
 
 ## Create a Kubernetes Secret that containes the HuggingFace API key
 
-In the previous step we hard-coded the HuggingFace API key in the deploy,ment manifest as an environment variable. This is not a good practice as these kind of secrets might end up on Github.
+In the previous step we hard-coded the HuggingFace API key in the deployment manifest as an environment variable. This is not a good practice as these kind of secrets might end up on Github.
 
 Kubernetes has a mechanism to secure Secrets (passwords, API Keys...). Let's explore how to use it.
 

--- a/workshop/Step6.md
+++ b/workshop/Step6.md
@@ -22,7 +22,7 @@ Note that the value of the secret has been Base64 encoded
 
 Edit the file `k8s/secure/deployment.yaml`:
 
-- Change the value of `PROJECT_ID` to match your project ID
+- Change the value of `image` (from `nice-ocean-419714`) to match your project ID (run `gcloud config list` in the cloud shell to get your project ID)
 
 Run the command below to deploy the app
 

--- a/workshop/Step7.md
+++ b/workshop/Step7.md
@@ -44,7 +44,7 @@ Test the application in Cloud Run
 
 ```
 # find the app URL if you have not noted it
-gcloud run services list | grep devnexus-app
-✔  quotes                    us-east1   https://devnexus-...-uc.a.run.app       
+gcloud run services list | grep ml-java-workshopp-app
+✔  quotes                    us-east1   https://ml-java-workshopp-app-...-uc.a.run.app       
 ```
 Open the URL in a browser and test the application


### PR DESCRIPTION
These are a couple suggestions made during the workshop or problems found while following the guide step by step from Spring IO 2024. Let me know if you'd like something changed

Reasoning for changes:
- `pack sbom` CLI interface changed, it now requires a `download` subcommand, and the output is not the same. During the workshop you mentioned skipping over this since Docker scout achieves the same result
- Grype command updated since the installation mention on the GitHub repo moves the binary to `usr/local/bin` and that fails on Google Cloud Shell, the updated command just moves the binary in the current directory
- Other changes include typos, name mismatches and consistency changes